### PR TITLE
allow user to specify venn diagram pdf output location

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -85,6 +85,9 @@ metrics are generated:
 
 Venn diagrams
 ~~~~~~~~~~~~~
+
+By default, the Venn diagrams are output as PDFs in the current directory. The output location can be changed with the ``--venn_dir`` option.
+
 When 2 or 3 VCF files are compared, the following Venn diagrams are generated:
 
 * venn2.positions.pdf - Venn diagram of variant positions between all pairs of VCF files

--- a/vcftoolz/cli.py
+++ b/vcftoolz/cli.py
@@ -54,6 +54,7 @@ def parse_arguments(system_args):
     subparser.add_argument("--exclude_missing",  dest="exclude_missing",  action="store_true",      help="Exclude calls with all data elements missing.")
     subparser.add_argument("--truth",            dest="truth_flag",       action="store_true",      help="Additional metrics are generated assuming the first VCF file is the truth. This also triggers extra analysis of filtered calls.")
     subparser.add_argument("--tabulate",         dest="table_file",       type=str, metavar='FILE', help="Tabulate the results in the specified tab-separated-value file.")
+    subparser.add_argument("--venn_dir",         dest="venn_dir",         type=str, metavar='DIR',  help="Directory where Venn diagram PDFs should be saved.", default=".")
     subparser.set_defaults(func=compare_command)
 
     help_str = "Reformat VCF data into a tall, narrow format."
@@ -118,7 +119,7 @@ def compare_command(args):
     if args.truth_flag and len(vcf_path_list) != 2:
         logging.error("When the truth option is used, there must be exactly 2 VCF files.")
         exit(1)
-    vcftoolz.compare(args.truth_flag, vcf_path_list, args.exclude_snps, args.exclude_indels, args.exclude_vars, args.exclude_refs, args.exclude_hetero, args.exclude_filtered, args.exclude_missing, args.table_file)
+    vcftoolz.compare(args.truth_flag, vcf_path_list, args.exclude_snps, args.exclude_indels, args.exclude_vars, args.exclude_refs, args.exclude_hetero, args.exclude_filtered, args.exclude_missing, args.table_file, args.venn_dir)
 
 
 def narrow_command(args):

--- a/vcftoolz/vcftoolz.py
+++ b/vcftoolz/vcftoolz.py
@@ -446,7 +446,7 @@ def print_snp_detail_list(snp_set, alt_dict, format_dict, call_dict):
             print('\t'.join(fields))
 
 
-def compare(truth_flag, vcf_path_list, exclude_snps, exclude_indels, exclude_vars, exclude_refs, exclude_hetero, exclude_filtered, exclude_missing, table_file):
+def compare(truth_flag, vcf_path_list, exclude_snps, exclude_indels, exclude_vars, exclude_refs, exclude_hetero, exclude_filtered, exclude_missing, table_file, venn_dir):
     """
     Compare and analyze the snps found in two or more input VCF files.
 
@@ -474,6 +474,8 @@ def compare(truth_flag, vcf_path_list, exclude_snps, exclude_indels, exclude_var
         Exclude calls with all data elements missing.
     table_file_path : str
         Path to the TSV file to be written.
+    venn_dir: str
+        Directory where Venn diagram PDFs should be saved.
     """
     # Validate input files
     bad_files_count = verify_non_empty_input_files("VCF file", vcf_path_list)
@@ -730,7 +732,7 @@ def compare(truth_flag, vcf_path_list, exclude_snps, exclude_indels, exclude_var
                     colorize_venn2(c)
                     plt_idx += 1
                 axes[0].set_title(title)
-            plt.savefig(output_file)
+            plt.savefig("{0}/{1}".format(venn_dir, output_file))
             plt.close()
 
         make_venn2(snp_set_list, "Venn Diagram of SNPs", "venn2.snps.pdf")
@@ -758,7 +760,7 @@ def compare(truth_flag, vcf_path_list, exclude_snps, exclude_indels, exclude_var
         axes[plt_idx].set_title("SNPs", fontsize=titlesize)
 
         plt.subplots_adjust(hspace=0.5)  # adjust height spacing between subplots
-        plt.savefig("venn%i.pdf" % num_vcf_files)
+        plt.savefig("{0}/venn{1}.pdf".format(venn_dir, num_vcf_files))
         plt.close()
 
 


### PR DESCRIPTION
Currently, the Venn diagram is always stored in the current directory.

This can be an issue, e.g., when using `vcftoolz` in an automated pipeline, because any PDF files from a previous run will be overwritten.

This pull request adds the ability to specify where the output Venn diagram PDF files should be saved. A different directory can then be specified for each run.